### PR TITLE
Add 'all' target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ PREFIX ?= /usr
 PROGRAM = qf
 OBJS = $(subst .c,.o,$(wildcard *.c))
 
+all: $(PROGRAM)
+
 $(PROGRAM): $(OBJS)
 
 install: $(PROGRAM)
@@ -14,6 +16,6 @@ uninstall:
 $(OBJS): Makefile
 $(PROGRAM).o: $(wildcard *.h)
 
-.PHONY: clean install uninstall
+.PHONY: all clean install uninstall
 clean:
 	rm -f qf *.o


### PR DESCRIPTION
Add an `all` target to the Makefile and make it the default target as is customary. It is useful for a clean rebuild:

```
make clean all
```
