### PR TITLE
Extracted the prompt logic from qselect.cpp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endef
 prefix ?= /usr
 programs = qfind qselect
 qfind_objs = qfind.o dir.o match.o
-qselect_objs = qselect.o match.o term.o
+qselect_objs = qselect.o match.o term.o prompt.o
 
 CXXFLAGS += -std=c++14 -Wall -Werror
 

--- a/prompt.cpp
+++ b/prompt.cpp
@@ -1,0 +1,52 @@
+#include "prompt.h"
+#include <iostream>
+#include <iterator>
+
+Prompt::Prompt(Term& tty, const std::string& prompt)
+    : tty{tty}, prompt{prompt}
+      
+{
+    pos = search_query.begin();
+    tty.puts((prompt + "\n").c_str());
+}
+bool Prompt::handle_key(const Term::Key key)
+{
+    bool reset_selection = false;
+
+    switch (key) {
+    case Term::DEL:
+    case Term::BACKSPACE:
+        if (search_query.length() > 0 && pos != search_query.begin()) {
+            pos = std::prev(search_query.erase(pos));
+            tty.cursor_back(1);
+            tty.erase_line(Term::FORWARD);
+            reset_selection = true;
+        }
+        break;
+
+    case Term::CTRL_U:
+        search_query.clear();
+        pos = search_query.begin();
+        tty.move_to_col(1);
+        tty.puts(prompt.c_str());
+        reset_selection = true;
+        break;
+
+    default:
+        pos = std::next(search_query.insert(pos, key));
+        tty.putchar(key);
+        reset_selection = true;
+    }
+
+    tty.erase_display(Term::FORWARD);
+
+    return reset_selection;
+}
+
+int Prompt::current_column() {
+    return prompt.length() + std::distance(search_query.begin(), pos) + 1;
+}
+
+const std::string& Prompt::query() {
+    return search_query;
+}

--- a/prompt.h
+++ b/prompt.h
@@ -1,0 +1,18 @@
+#include <string>
+#include "term.h"
+
+class Prompt
+{
+public:
+    Prompt(Term& tty, const std::string& prompt);
+
+    bool handle_key(const Term::Key key);
+    int current_column();
+    const std::string& query();
+
+private:
+    Term tty;
+    std::string prompt;
+    std::string search_query;
+    std::string::iterator pos;
+};

--- a/term.cpp
+++ b/term.cpp
@@ -41,6 +41,10 @@ int Term::puts(const char *str)
     return fprintf(tty, "%s", str);
 }
 
+int Term::puts_highlighted(const char *str) {
+    return fprintf(tty, "\033[7m%s\033[0m", str);
+}
+
 int Term::putchar(int ch){
     return fputc(ch, tty);
 }

--- a/term.h
+++ b/term.h
@@ -59,6 +59,7 @@ public:
     ~Term();
 
     int puts(const char *str);
+    int puts_highlighted(const char *str);
     int putchar(int ch);
     int getchar();
 


### PR DESCRIPTION
this branch extracts the prompt rendering logic (mostly) from the qselect file so that it is easy to add functionality to the prompt like supporting other emacs style keybindings (ctrl-a, ctrl-e) etc.